### PR TITLE
PersistenceDiagram Class

### DIFF
--- a/curvature_filtrations/compare.py
+++ b/curvature_filtrations/compare.py
@@ -84,14 +84,13 @@ class Comparator:
 
     @staticmethod
     def _format_inputs(G):
+        """Always returns a list of graphs."""
         if Comparator._is_distribution(G):
             return G
         elif Comparator._is_graph(G):
             return [G]
         else:
-            raise ValueError(
-                "Input must be a networkx.Graph or a list of networkx.Graphs"
-            )
+            raise ValueError("Input must be a networkx.Graph or a list of networkx.Graphs")
 
     @staticmethod
     def _is_distribution(G):

--- a/curvature_filtrations/kilt.py
+++ b/curvature_filtrations/kilt.py
@@ -9,11 +9,12 @@ from curvature_filtrations.topology.ph import (
     GraphHomology,
 )
 
+# methods for calculating curvature that KILT currently supports
 CURVATURE_MEASURES = [
     "forman_curvature",
     "ollivier_ricci_curvature",
     "resistance_curvature",
-]  # methods for calculating curvature that KILT currently supports
+]
 
 
 class KILT:
@@ -51,13 +52,13 @@ class KILT:
     curvature:
         Getter (self -> np.array) and setter (self, np.array -> None) for np.array of the graph's curvature values.
 
-    fit(self, graph: nx.Graph) -> None
+    fit(self, graph: nx.Graph) -> None:
         Calculates the curvature values for the edges of the given graph according to the specifications of the KILT object, which can be retrieved from the curvature property.
 
-    transform(self, homology_dims: Optional[List[int]] = [0, 1],) -> Dict[int, np.array]:
+    transform(self, homology_dims: Optional[List[int]] = [0, 1],) -> PersistenceDiagram:
         Executes a curvature filtration for the given homology dimensions. Can only be called after fit() is performed. Returns a persistence diagram stored in dictionary format.
 
-    fit_transform(self, graph, homology_dims: Optional[List[int]] = [0, 1]) -> Dict[int, np.array]:
+    fit_transform(self, graph, homology_dims: Optional[List[int]] = [0, 1]) -> PersistenceDiagram:
         Combines fit and transform methods; i.e. calculates curvature and executes a filtration for the given homology dimensions. Returns a persistence diagram stored in dictionary format.
     """
 
@@ -105,46 +106,24 @@ class KILT:
 
     @property
     def G(self) -> nx.Graph:
-        """Get the graph associated with the KILT object.
-        Returns
-        -------
-        nx.Graph
-            The graph assigned to the KILT object.
-        """
+        """Getter method for the graph associated with the KILT object."""
         return self._G
 
     @G.setter
     def G(self, graph) -> None:
-        """Set the given graph as the KILT object's graph attribute.
-        Parameters
-        ----------
-        graph : nx.Graph
-            The graph to be assigned to the KILT object.
-        """
+        """Setter method which sets the given graph as the KILT object's graph attribute."""
         self._G = graph.copy()
 
     @property
     def curvature(self) -> np.array:
-        """Return the curvature values of the graph.
-        Returns
-        -------
-        np.array
-            The curvature values for the edges of the graph associated with the KILT object.
-        """
+        """Getter method for the curvature values of the graph."""
         if self.G is None:
             return None
-        return self._unpack_curvature_values(
-            nx.get_edge_attributes(self.G, name=self.measure)
-        )
+        return self._unpack_curvature_values(nx.get_edge_attributes(self.G, name=self.measure))
 
     @curvature.setter
-    def curvature(self, values) -> None:
-        """Set the curvature values of the graph.
-        Parameters
-        ----------
-        values : list
-            The graph to be assigned to the KILT object.
-        """
+    def curvature(self, values: list) -> None:
+        """Setter method for the curvature values of the graph."""
         edge_map = self._pack_curvature_values(self.G.edges, values)
         nx.set_edge_attributes(self.G, edge_map, name=self.measure)
 
@@ -191,10 +170,8 @@ class KILT:
 
         Returns
         -------
-        Dict[int, np.array]
-            A persistence diagram.
-                Keys: Integers that correspond to homology dimensions.
-                Values: np.arrays that contain all persistence pairs in the form of [birth, death] tuples.
+        PersistenceDiagram
+            A persistence diagram that stores the topological information from a curvature filtration.
         """
         ph = GraphHomology(homology_dims, self.measure)
         assert (
@@ -225,10 +202,8 @@ class KILT:
 
         Returns
         -------
-        Dict[int, np.array]
-            A persistence diagram.
-                Keys: Integers that correspond to homology dimensions.
-                Values: np.arrays that contain all persistence pairs in the form of [birth, death] tuples.
+        PersistenceDiagram
+            A persistence diagram that stores the topological information from a curvature filtration.
         """
         self.fit(graph)
         return self.transform(homology_dims)

--- a/curvature_filtrations/kilt.py
+++ b/curvature_filtrations/kilt.py
@@ -171,7 +171,8 @@ class KILT:
         Returns
         -------
         PersistenceDiagram
-            A persistence diagram that stores the topological information from a curvature filtration.
+            A persistence diagram wrapper for the topological information from a curvature filtration.
+            Attribute persistence_pts stores a Dict[int, np.array] that a maps homology dimension key to a np.array of its persistence pairs.
         """
         ph = GraphHomology(homology_dims, self.measure)
         assert (
@@ -203,7 +204,8 @@ class KILT:
         Returns
         -------
         PersistenceDiagram
-            A persistence diagram that stores the topological information from a curvature filtration.
+            A persistence diagram wrapper for the topological information from a curvature filtration.
+            Attribute persistence_pts stores a Dict[int, np.array] that a maps homology dimension key to a np.array of its persistence pairs.
         """
         self.fit(graph)
         return self.transform(homology_dims)

--- a/curvature_filtrations/topology/distances.py
+++ b/curvature_filtrations/topology/distances.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from typing import Dict, List
 import gudhi as gd
+from curvature_filtrations.topology.ph import PersistenceDiagram
 
 
 class TopologicalDistance(ABC):
@@ -69,9 +70,7 @@ class LandscapeDistance(TopologicalDistance):
         avg2 = self._average_landscape(landscapes2)
         return avg1, avg2
 
-    def transform(
-        self, landscape1: Dict[int, np.array], landscape2: Dict[int, np.array]
-    ) -> float:
+    def transform(self, landscape1: Dict[int, np.array], landscape2: Dict[int, np.array]) -> float:
         """Compute the norm-based distance between two persistence landscapes."""
         common_dims = set(landscape1.keys()).intersection(landscape2.keys())
         difference = self._subtract_landscapes(landscape1, landscape2)
@@ -80,22 +79,27 @@ class LandscapeDistance(TopologicalDistance):
         return distance
 
     def _convert_to_landscape(
-        self, diagrams: List[Dict[int, np.array]]
-    ) -> List[Dict[int, np.array]]:
+        self, diagrams: List[PersistenceDiagram]
+    ) -> List[Dict[int, np.array]]:  # TODO: add PD
         """Convert each persistence diagram to a persistence landscape for each dimension."""
         landscapes = []
+
         for diagram in diagrams:
-            landscape = {
-                dim: self.landscape_transformer.fit_transform([points])[0]
-                for dim, points in diagram.items()
-            }
+            # from before change to PersistenceDiagram object:
+            # landscape = {
+            #     dim: self.landscape_transformer.fit_transform([points])[0]
+            #     for dim, points in diagram.items()
+            # }
+            landscape = {}
+            for dim, points in diagram.persistence_pts.items():
+                transformed_points = self.landscape_transformer.fit_transform([points])[0]
+                landscape[dim] = transformed_points
             landscapes.append(landscape)
+
         return landscapes
 
     @staticmethod
-    def _average_landscape(
-        landscapes: List[Dict[int, np.array]]
-    ) -> Dict[int, np.array]:
+    def _average_landscape(landscapes: List[Dict[int, np.array]]) -> Dict[int, np.array]:
         """Compute the average persistence landscape across multiple landscapes."""
         avg_landscape = {}
         for landscape in landscapes:

--- a/curvature_filtrations/topology/distances.py
+++ b/curvature_filtrations/topology/distances.py
@@ -80,7 +80,7 @@ class LandscapeDistance(TopologicalDistance):
 
     def _convert_to_landscape(
         self, diagrams: List[PersistenceDiagram]
-    ) -> List[Dict[int, np.array]]:  # TODO: add PD
+    ) -> List[Dict[int, np.array]]:
         """Convert each persistence diagram to a persistence landscape for each dimension."""
         landscapes = []
 

--- a/curvature_filtrations/topology/ph.py
+++ b/curvature_filtrations/topology/ph.py
@@ -19,10 +19,11 @@ class PersistenceDiagram:
         Dimensions of the homology groups to compute (e.g., [0, 1] for H_0 and H_1).
         Default is [0, 1].
 
-    _persistence_points : Dict[int, np.array]
+    _persistence_points : None or Dict[int, np.array]
         A dictionary that maps the homology dimension to a np.array of its persistence pairs.
         Each np.array contains tuples of (birth, death) values for each persistence pair.
         Note that the attribute homology_dims must be a subset of the list of keys (hom. dims.) in this dictionary.
+        Initialized to None, set using setter method.
 
     Methods
     -------
@@ -127,8 +128,8 @@ class GraphHomology:
         Returns
         -------
         PersistenceDiagram
-            Object that stores the raw data from a persistence diagram created by a filtration,
-            i.e. stores all persistence (birth,death) pairs for each homology dimension.
+            A persistence diagram wrapper for the topological information from a curvature filtration.
+            Attribute persistence_pts stores a Dict[int, np.array] that a maps homology dimension key to a np.array of its persistence pairs.
 
         Raises
         ------
@@ -190,8 +191,8 @@ class GraphHomology:
         Returns
         -------
         PersistenceDiagram
-            Object that stores the raw data from a persistence diagram created by a filtration,
-            i.e. stores all persistence (birth,death) pairs for each homology dimension.
+            A persistence diagram wrapper for the topological information from a curvature filtration.
+            Attribute persistence_pts stores a Dict[int, np.array] that a maps homology dimension key to a np.array of its persistence pairs.
         """
         # initialize PersistenceDiagram object
         diagram = PersistenceDiagram(self.homology_dims)

--- a/curvature_filtrations/topology/ph.py
+++ b/curvature_filtrations/topology/ph.py
@@ -77,6 +77,20 @@ class GraphHomology:
     This class uses Gudhi's `SimplexTree` to build a clique complex on a given
     graph and compute persistence diagrams for homology groups, using an edge
     attribute (e.g. curvature) as a filtration function.
+
+    Attributes
+    ----------
+    homology_dims : List[int]
+        Dimensions of the homology groups to compute (e.g., [0, 1] for H_0 and H_1).
+        Default is [0, 1].
+
+    filter_attribute : str, optional
+        The edge attribute to use as the filtration value. Default is "curvature".
+
+    Methods
+    -------
+    calculate_persistent_homology(self, G : nx.Graph, extended_persistence: bool = False) -> PersistenceDiagram):
+        Uses helper methods _build_simplex_tree to execute a filtration on the given graph and _format_persistence_diagrams to store the resulting persistent homology data in a PersistenceDiagram object.
     """
 
     def __init__(

--- a/curvature_filtrations/topology/ph.py
+++ b/curvature_filtrations/topology/ph.py
@@ -11,7 +11,7 @@ from joblib import Parallel, delayed
 
 
 class PersistenceDiagram:
-    """A wrapper object for the data housed in a persistence diagram.
+    """A wrapper object for the data housed in a persistence diagram for the specified homology dimensions.
 
     Attributes
     ----------
@@ -112,10 +112,9 @@ class GraphHomology:
 
         Returns
         -------
-        Dict[int, np.array]
-            Persistence diagrams for each dimension up to `max_dimension`.
-            Dictionary maps the homology dimension to a np.array of its persistence pairs.
-            Each np.array contains tuples of (birth, death) values for each persistence pair.
+        PersistenceDiagram
+            Object that stores the raw data from a persistence diagram created by a filtration,
+            i.e. stores all persistence (birth,death) pairs for each homology dimension.
 
         Raises
         ------
@@ -167,28 +166,31 @@ class GraphHomology:
 
     def _format_persistence_diagrams(self, simplex_tree: gd.SimplexTree) -> Dict[int, np.array]:
         """
-        Formats persistence pairs into diagrams for each specified homology dimension.
+        Converts a gd.SimplexTree into a PersistenceDiagram object.
 
         Parameters
         ----------
-        persistence_pairs : list of tuples
-            Persistence pairs returned by Gudhi's persistence computation. Each tuple
-            is of the form (dimension, (birth, death)).
+        simplex_tree: gd.SimplexTree
+            Simplex tree built from the graph by conducting a filtration.
 
         Returns
         -------
-        Dict[int, np.array]
-            Persistence diagrams for each dimension up to `max_dimension`.
-            Dictionary maps the homology dimension to a np.array of its persistence pairs.
-            Each np.array contains tuples of (birth, death) values for each persistence pair.
+        PersistenceDiagram
+            Object that stores the raw data from a persistence diagram created by a filtration,
+            i.e. stores all persistence (birth,death) pairs for each homology dimension.
         """
-        diagrams = {}
+        # initialize PersistenceDiagram object
+        diagram = PersistenceDiagram(self.homology_dims)
+        # format dictionary of mapping persistence points to homology dimensions for input into PersistenceDiagram object
+        persistance_pts = {}
         for dim in self.homology_dims:
             persistence_pairs = self._mask_infinities(
                 simplex_tree.persistence_intervals_in_dimension(dim)
             )
-            diagrams[dim] = persistence_pairs
-        return diagrams
+            persistance_pts[dim] = persistence_pairs
+        # store persistence points in PersistenceDiagram object
+        diagram.persistence_pts = persistance_pts
+        return diagram
 
     @staticmethod
     def _mask_infinities(array):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,14 +41,16 @@ def regular_homology_dims():
 @pytest.fixture
 def toy_diagram1():
     """Toy persistence diagram with 0D and 1D homology features."""
-    return [
-        {0: np.array([[0, 1], [1, 2]]), 1: np.array([[0.5, 2.0], [1.5, 2.5]])}
-    ]
+    return [{0: np.array([[0, 1], [1, 2]]), 1: np.array([[0.5, 2.0], [1.5, 2.5]])}]
 
 
 @pytest.fixture
 def toy_diagram2():
     """Toy persistence diagram with 0D and 1D homology features."""
-    return [
-        {0: np.array([[0, 1], [1, 3]]), 1: np.array([[0.5, 2.1], [1.5, 3.0]])}
-    ]
+    return [{0: np.array([[0, 1], [1, 3]]), 1: np.array([[0.5, 2.1], [1.5, 3.0]])}]
+
+
+@pytest.fixture
+def diagram_dict():
+    """Toy input for making a Diagram object (output of the persistent homology )"""
+    return {0: np.array([[-24.0, -20.0], [-23.0, -19.0], [-19.0, -18.0]]), 1: np.array([-21, -20])}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,6 @@ def toy_diagram2():
 
 
 @pytest.fixture
-def diagram_dict():
+def dummy_diagram():
     """Toy input for making a Diagram object (output of the persistent homology )"""
     return {0: np.array([[-24.0, -20.0], [-23.0, -19.0], [-19.0, -18.0]]), 1: np.array([-21, -20])}

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,7 +1,7 @@
 import pytest
 from curvature_filtrations.compare import Comparator
 from curvature_filtrations.kilt import KILT
-from curvature_filtrations.topology.ph import GraphHomology
+from curvature_filtrations.topology.ph import GraphHomology, PersistenceDiagram
 from curvature_filtrations.topology.distances import (
     LandscapeDistance,
 )

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -2,6 +2,7 @@ import pytest
 import networkx as nx
 import numpy as np
 from curvature_filtrations.topology.ph import GraphHomology, PersistenceDiagram
+from curvature_filtrations.kilt import KILT
 
 
 class TestDiagram:
@@ -28,3 +29,8 @@ class TestDiagram:
         diagram.persistence_pts = diagram_dict
         print(diagram_dict[0])
         assert np.all(diagram.get_pts_for_dim(0) == diagram_dict[0])
+
+    def test_ph_calc(self, graph):
+        klt = KILT()
+        ph = klt.fit_transform(graph)
+        assert type(ph) == PersistenceDiagram

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -1,0 +1,30 @@
+import pytest
+import networkx as nx
+import numpy as np
+from curvature_filtrations.topology.ph import GraphHomology, PersistenceDiagram
+
+
+class TestDiagram:
+
+    def test_create_object(self):
+        diagram = PersistenceDiagram()
+        assert type(diagram) == PersistenceDiagram
+
+    def test_defaults(self):
+        diagram = PersistenceDiagram()
+        assert diagram.homology_dims == [0, 1]
+        assert diagram.persistence_pts == None
+
+    def test_set_persistence_pts(self, diagram_dict):
+        diagram = PersistenceDiagram()
+        assert diagram._persistence_pts == None
+        # setting persistence points
+        diagram.persistence_pts = diagram_dict
+        assert diagram.persistence_pts == diagram_dict
+
+    def test_get_pts_for_dim(self, diagram_dict):
+        diagram = PersistenceDiagram()
+        # set and get
+        diagram.persistence_pts = diagram_dict
+        print(diagram_dict[0])
+        assert np.all(diagram.get_pts_for_dim(0) == diagram_dict[0])

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -16,19 +16,19 @@ class TestDiagram:
         assert diagram.homology_dims == [0, 1]
         assert diagram.persistence_pts == None
 
-    def test_set_persistence_pts(self, diagram_dict):
+    def test_set_persistence_pts(self, dummy_diagram):
         diagram = PersistenceDiagram()
         assert diagram._persistence_pts == None
         # setting persistence points
-        diagram.persistence_pts = diagram_dict
-        assert diagram.persistence_pts == diagram_dict
+        diagram.persistence_pts = dummy_diagram
+        assert diagram.persistence_pts == dummy_diagram
 
-    def test_get_pts_for_dim(self, diagram_dict):
+    def test_get_pts_for_dim(self, dummy_diagram):
         diagram = PersistenceDiagram()
         # set and get
-        diagram.persistence_pts = diagram_dict
-        print(diagram_dict[0])
-        assert np.all(diagram.get_pts_for_dim(0) == diagram_dict[0])
+        diagram.persistence_pts = dummy_diagram
+        print(dummy_diagram[0])
+        assert np.all(diagram.get_pts_for_dim(0) == dummy_diagram[0])
 
     def test_ph_calc(self, graph):
         klt = KILT()

--- a/tests/test_kilt.py
+++ b/tests/test_kilt.py
@@ -3,6 +3,7 @@ from curvature_filtrations.kilt import KILT
 import networkx as nx
 import numpy as np
 import curvature_filtrations.geometry.measures as measures
+from curvature_filtrations.topology.ph import PersistenceDiagram
 
 
 class TestKILT:
@@ -94,26 +95,26 @@ class TestKILT:
         # Use fit to set curvature
         klt.fit(graph)
         diagram = klt.transform(homology_dims=regular_homology_dims)
-        assert isinstance(diagram, dict)
+        assert isinstance(diagram, PersistenceDiagram)
         for dim in regular_homology_dims:
-            assert dim in diagram.keys()
-            isinstance(diagram[dim], np.ndarray)
+            assert dim in diagram.homology_dims
+            isinstance(diagram.get_pts_for_dim(dim), np.ndarray)
 
     def test_fit_transform(self, graph, graph2, small_graph):
         klt = KILT(measure="forman_curvature")
         diagram1 = klt.fit_transform(graph)
         curv1 = klt.curvature
-        assert isinstance(diagram1, dict)
+        assert isinstance(diagram1, PersistenceDiagram)
 
         small_diagram = klt.fit_transform(small_graph)
         small_curv = klt.curvature
-        assert isinstance(small_diagram, dict)
+        assert isinstance(small_diagram, PersistenceDiagram)
 
         assert not len(curv1) == len(small_curv)
 
         diagram2 = klt.fit_transform(graph2)
         curv2 = klt.curvature
-        assert isinstance(diagram2, dict)
+        assert isinstance(diagram2, PersistenceDiagram)
 
         if len(curv1) == len(curv2):
             assert not np.array_equal(curv1, curv2)

--- a/tests/topology/conftest.py
+++ b/tests/topology/conftest.py
@@ -1,22 +1,19 @@
 import pytest
 import numpy as np
 from curvature_filtrations.topology.distances import LandscapeDistance
+from curvature_filtrations.topology.ph import PersistenceDiagram
 
 
 @pytest.fixture
 def toy_diagram1():
     """Toy persistence diagram with 0D and 1D homology features."""
-    return [
-        {0: np.array([[0, 1], [1, 2]]), 1: np.array([[0.5, 2.0], [1.5, 2.5]])}
-    ]
+    return [{0: np.array([[0, 1], [1, 2]]), 1: np.array([[0.5, 2.0], [1.5, 2.5]])}]
 
 
 @pytest.fixture
 def toy_diagram2():
     """Toy persistence diagram with 0D and 1D homology features."""
-    return [
-        {0: np.array([[0, 1], [1, 3]]), 1: np.array([[0.5, 2.1], [1.5, 3.0]])}
-    ]
+    return [{0: np.array([[0, 1], [1, 3]]), 1: np.array([[0.5, 2.1], [1.5, 3.0]])}]
 
 
 @pytest.fixture
@@ -32,9 +29,33 @@ def toy_diagram4():
 
 
 @pytest.fixture
-def setup_landscape_distance(toy_diagram1, toy_diagram2):
+def toy_pd(toy_diagram1):
+    """Toy PersistenceDiagram object"""
+    input_dict = {}
+    dims = []
+    for dim, array in toy_diagram1[0].items():
+        input_dict[dim] = array
+        dims.append(dim)
+    pd = PersistenceDiagram(dims)
+    pd.persistence_pts = input_dict
+    return [pd]
+
+
+@pytest.fixture
+def toy_pd2(toy_diagram2):
+    """Toy PersistenceDiagram object"""
+    input_dict = {}
+    dims = []
+    for dim, array in toy_diagram2[0].items():
+        input_dict[dim] = array
+        dims.append(dim)
+    pd = PersistenceDiagram(dims)
+    pd.persistence_pts = input_dict
+    return [pd]
+
+
+@pytest.fixture
+def setup_landscape_distance(toy_pd, toy_pd2):
     """Fixture to set up the LandscapeDistance instance and sample diagrams."""
-    landscape_distance = LandscapeDistance(
-        toy_diagram1, toy_diagram2, norm=2, resolution=1000
-    )
+    landscape_distance = LandscapeDistance(toy_pd, toy_pd2, norm=2, resolution=1000)
     return landscape_distance


### PR DESCRIPTION
# Adding the PersistenceDiagram class.

## Notes:
Temporarily in **topology/ph.py** , but eventually can make a **data_types.py** file in topology that also includes Landscape, Image, etc.

## Changes made:
- [X] - Created PersistenceDiagram class (really just a shell for the data, which is still mainly stored in a dictionary)
- [X] - Added new tests file to help while creating object: **tests/test_diagram.py**
- [X] - Updated fixtures in conftest. Getting comfier with pytest... so convenient!
- [X] - Now **transform** and **fit_transform** methods in KILT return PersistenceDiagram object (necessary changes were made to GraphHomology class for this purpose)
- [X] - Made needed changes to other test files (some checked types which have changed)
- [X] - I believe I made all necessary changes to **distances.py** (especially **_convert_to_landscapes** method) so that everything is running smoothly with LandscapeDistance and by extension Comparator 

_Passes all existing tests :)_

## Next Emily Things (perhaps in a new branch):
- Implement ImageDistance and SilhouetteDistance
- Add Landscape Class (and classes for other vectorizations of PersistenceDiagrams, i.e. Image, Silhouette)

